### PR TITLE
Workaround for sr-13263

### DIFF
--- a/Sources/TensorFlow/Layers/Normalization.swift
+++ b/Sources/TensorFlow/Layers/Normalization.swift
@@ -105,8 +105,7 @@ public struct BatchNorm<Scalar: TensorFlowFloatingPoint>: Layer {
     precondition(
       input.shape[positiveAxis] == offset.shape[0],
       "The number of features of the input and the offset doesn't match.")
-//     var offset = self.offset
-//     var scale = self.scale
+//     var (offset, scale) = {x in (x.offset, x.scale) }(self)
 //     if positiveAxis != input.rank - 1 {
 //       var broadcastShape = TensorShape([Int](repeating: 1, count: input.rank))
 //       broadcastShape[positiveAxis] = input.shape[positiveAxis]
@@ -115,10 +114,10 @@ public struct BatchNorm<Scalar: TensorFlowFloatingPoint>: Layer {
 //     }
     let offsetOriginal = self.offset
     let scaleOriginal = self.scale
-    let (offset, scale) = Self.srNameWorkaround(offset: offsetOriginal,
-                                                scale: scaleOriginal,
-                                                input: input,
-                                                positiveAxis: positiveAxis)
+    let (offset, scale) = Self._sr13263workaround(offset: offsetOriginal,
+                                                  scale: scaleOriginal,
+                                                  input: input,
+                                                  positiveAxis: positiveAxis)
     switch Context.local.learningPhase {
     case .training:
       return doTraining(input, offset: offset, scale: scale, axis: positiveAxis)
@@ -129,7 +128,7 @@ public struct BatchNorm<Scalar: TensorFlowFloatingPoint>: Layer {
   
   @inline(never)
   @differentiable(reverse) // if the function is `public` or `internal`, the compiler crashes
-  private static func srNameWorkaround( // if this doesn't work, try a fileprivate generic struct
+  private static func _sr13263workaround(
     offset: Tensor<Scalar>, 
     scale: Tensor<Scalar>,
     input: Tensor<Scalar>,

--- a/Sources/TensorFlow/Layers/Normalization.swift
+++ b/Sources/TensorFlow/Layers/Normalization.swift
@@ -115,12 +115,12 @@ public struct BatchNorm<Scalar: TensorFlowFloatingPoint>: Layer {
 //       offset = offset.reshaped(to: broadcastShape)
 //       scale = scale.reshaped(to: broadcastShape)
 //     }
-    if positiveAxis != input.rank - 1 {
-      Self.srNameWorkaround(offset: &offset,
-                                              scale: &scale,
+//     if positiveAxis != input.rank - 1 {
+      (offset, scale) = Self.srNameWorkaround(offset: offset,
+                                              scale: scale,
                                               input: input,
                                               positiveAxis: positiveAxis)
-    }
+//     }
 //     let (offset, scale) = Self.srNameWorkaround(offset: offsetOriginal,
 //                                                 scale: scaleOriginal,
 //                                                 input: input,
@@ -135,23 +135,24 @@ public struct BatchNorm<Scalar: TensorFlowFloatingPoint>: Layer {
   
   @inline(never)
   @differentiable(reverse)
-  private static func srNameWorkaround(
-    offset: inout Tensor<Scalar>, 
-    scale: inout Tensor<Scalar>,
+  private static func srNameWorkaround( // if this doesn't work, try a fileprivate generic struct
+    offset: Tensor<Scalar>, 
+    scale: Tensor<Scalar>,
     input: Tensor<Scalar>,
     positiveAxis: Int
-  ) {
+  ) -> (Tensor<Scalar>, Tensor<Scalar>) {
 //     var offsetCopy = offset
 //     var scaleCopy = offset
     
-//     if positiveAxis != input.rank - 1 {
+    if positiveAxis != input.rank - 1 {
       var broadcastShape = TensorShape([Int](repeating: 1, count: input.rank))
       broadcastShape[positiveAxis] = input.shape[positiveAxis]
-      offset = offset.reshaped(to: broadcastShape)
-      shape = scale.reshaped(to: broadcastShape)
+      return (offset.reshaped(to: broadcastShape), scale.reshaped(to: broadcastShape))
 //       offsetCopy = offsetCopy.reshaped(to: broadcastShape)
 //       scaleCopy = scaleCopy.reshaped(to: broadcastShape)
-//     }
+    } else {
+      return (offset, scale)
+    }
     
 //     return (offsetCopy, scaleCopy)
   }

--- a/Sources/TensorFlow/Layers/Normalization.swift
+++ b/Sources/TensorFlow/Layers/Normalization.swift
@@ -124,9 +124,9 @@ public struct BatchNorm<Scalar: TensorFlowFloatingPoint>: Layer {
     
     // Remove this workaround ASAP allow inlining of `doTraining` and `doInference`
     if positiveAxis == input.rank - 1 {
-      callAsFunction1(input, positiveAxis: positiveAxis)
+      return callAsFunction1(input, positiveAxis: positiveAxis)
     } else {
-      callAsFunction2(input, positiveAxis: positiveAxis)
+      return callAsFunction2(input, positiveAxis: positiveAxis)
     }
   }
   

--- a/Sources/TensorFlow/Layers/Normalization.swift
+++ b/Sources/TensorFlow/Layers/Normalization.swift
@@ -107,8 +107,8 @@ public struct BatchNorm<Scalar: TensorFlowFloatingPoint>: Layer {
       "The number of features of the input and the offset doesn't match.")
 //     let offsetOriginal = self.offset
 //     let scaleOriginal = self.scale
-    var offset = self.offset
-    var scale = self.scale
+    let offsetOriginal = self.offset
+    let scaleOriginal = self.scale
 //     if positiveAxis != input.rank - 1 {
 //       var broadcastShape = TensorShape([Int](repeating: 1, count: input.rank))
 //       broadcastShape[positiveAxis] = input.shape[positiveAxis]
@@ -116,10 +116,10 @@ public struct BatchNorm<Scalar: TensorFlowFloatingPoint>: Layer {
 //       scale = scale.reshaped(to: broadcastShape)
 //     }
 //     if positiveAxis != input.rank - 1 {
-      (offset, scale) = Self.srNameWorkaround(offset: offset,
-                                              scale: scale,
-                                              input: input,
-                                              positiveAxis: positiveAxis)
+     let (offset, scale) = Self.srNameWorkaround(offset: offsetOriginal,
+                                                 scale: scaleOriginal,
+                                                 input: input,
+                                                 positiveAxis: positiveAxis)
 //     }
 //     let (offset, scale) = Self.srNameWorkaround(offset: offsetOriginal,
 //                                                 scale: scaleOriginal,

--- a/Sources/TensorFlow/Layers/Normalization.swift
+++ b/Sources/TensorFlow/Layers/Normalization.swift
@@ -128,8 +128,8 @@ public struct BatchNorm<Scalar: TensorFlowFloatingPoint>: Layer {
   }
   
   @inline(never)
-  @differentiable(reverse)
-  internal static func srNameWorkaround( // if this doesn't work, try a fileprivate generic struct --- remove `public` after debugging
+  @differentiable(reverse) // if the function is `public` or `internal`, the compiler crashes
+  private static func srNameWorkaround( // if this doesn't work, try a fileprivate generic struct
     offset: Tensor<Scalar>, 
     scale: Tensor<Scalar>,
     input: Tensor<Scalar>,

--- a/Sources/TensorFlow/Layers/Normalization.swift
+++ b/Sources/TensorFlow/Layers/Normalization.swift
@@ -129,7 +129,7 @@ public struct BatchNorm<Scalar: TensorFlowFloatingPoint>: Layer {
   
   @inline(never)
   @differentiable(reverse)
-  private static func srNameWorkaround( // if this doesn't work, try a fileprivate generic struct
+  public static func srNameWorkaround( // if this doesn't work, try a fileprivate generic struct --- remove `public` after debugging
     offset: Tensor<Scalar>, 
     scale: Tensor<Scalar>,
     input: Tensor<Scalar>,

--- a/Sources/TensorFlow/Layers/Normalization.swift
+++ b/Sources/TensorFlow/Layers/Normalization.swift
@@ -105,19 +105,21 @@ public struct BatchNorm<Scalar: TensorFlowFloatingPoint>: Layer {
     precondition(
       input.shape[positiveAxis] == offset.shape[0],
       "The number of features of the input and the offset doesn't match.")
-    let offsetOriginal = self.offset
-    let scaleOriginal = self.scale
-//     if positiveAxis != input.rank - 1 {
-//       var broadcastShape = TensorShape([Int](repeating: 1, count: input.rank))
-//       broadcastShape[positiveAxis] = input.shape[positiveAxis]
-//       offset = offset.reshaped(to: broadcastShape)
-//
-//       scale = scale.reshaped(to: broadcastShape)
-//     }
-    let (offset, scale) = Self.srNameWorkaround(offset: offsetOriginal,
-                                                scale: scaleOriginal,
-                                                input: input,
-                                                positiveAxis: positiveAxis)
+//     let offsetOriginal = self.offset
+//     let scaleOriginal = self.scale
+    var offset = self.offset
+    var scale = self.scale
+    if positiveAxis != input.rank - 1 {
+      var broadcastShape = TensorShape([Int](repeating: 1, count: input.rank))
+      broadcastShape[positiveAxis] = input.shape[positiveAxis]
+      offset = offset.reshaped(to: broadcastShape)
+
+      scale = scale.reshaped(to: broadcastShape)
+    }
+//     let (offset, scale) = Self.srNameWorkaround(offset: offsetOriginal,
+//                                                 scale: scaleOriginal,
+//                                                 input: input,
+//                                                 positiveAxis: positiveAxis)
     switch Context.local.learningPhase {
     case .training:
       return doTraining(input, offset: offset, scale: scale, axis: positiveAxis)

--- a/Sources/TensorFlow/Layers/Normalization.swift
+++ b/Sources/TensorFlow/Layers/Normalization.swift
@@ -129,7 +129,7 @@ public struct BatchNorm<Scalar: TensorFlowFloatingPoint>: Layer {
   
   @inline(never)
   @differentiable(reverse)
-  public static func srNameWorkaround( // if this doesn't work, try a fileprivate generic struct --- remove `public` after debugging
+  private static func srNameWorkaround( // if this doesn't work, try a fileprivate generic struct --- remove `public` after debugging
     offset: Tensor<Scalar>, 
     scale: Tensor<Scalar>,
     input: Tensor<Scalar>,

--- a/Sources/TensorFlow/Layers/Normalization.swift
+++ b/Sources/TensorFlow/Layers/Normalization.swift
@@ -109,11 +109,17 @@ public struct BatchNorm<Scalar: TensorFlowFloatingPoint>: Layer {
 //     let scaleOriginal = self.scale
     var offset = self.offset
     var scale = self.scale
+//     if positiveAxis != input.rank - 1 {
+//       var broadcastShape = TensorShape([Int](repeating: 1, count: input.rank))
+//       broadcastShape[positiveAxis] = input.shape[positiveAxis]
+//       offset = offset.reshaped(to: broadcastShape)
+//       scale = scale.reshaped(to: broadcastShape)
+//     }
     if positiveAxis != input.rank - 1 {
-      var broadcastShape = TensorShape([Int](repeating: 1, count: input.rank))
-      broadcastShape[positiveAxis] = input.shape[positiveAxis]
-      offset = offset.reshaped(to: broadcastShape)
-      scale = scale.reshaped(to: broadcastShape)
+      (offset, scale) = Self.srNameWorkaround(offset: offset,
+                                              scale: scale,
+                                              input: input,
+                                              positiveAxis: positiveAxis)
     }
 //     let (offset, scale) = Self.srNameWorkaround(offset: offsetOriginal,
 //                                                 scale: scaleOriginal,
@@ -135,17 +141,18 @@ public struct BatchNorm<Scalar: TensorFlowFloatingPoint>: Layer {
     input: Tensor<Scalar>,
     positiveAxis: Int
   ) -> (Tensor<Scalar>, Tensor<Scalar>) {
-    var offsetCopy = offset
-    var scaleCopy = offset
+//     var offsetCopy = offset
+//     var scaleCopy = offset
     
-    if positiveAxis != input.rank - 1 {
+//     if positiveAxis != input.rank - 1 {
       var broadcastShape = TensorShape([Int](repeating: 1, count: input.rank))
       broadcastShape[positiveAxis] = input.shape[positiveAxis]
-      offsetCopy = offsetCopy.reshaped(to: broadcastShape)
-      scaleCopy = scaleCopy.reshaped(to: broadcastShape)
-    }
+      return (offset.reshaped(to: broadcastShape), scale.reshaped(to: broadcastShape))
+//       offsetCopy = offsetCopy.reshaped(to: broadcastShape)
+//       scaleCopy = scaleCopy.reshaped(to: broadcastShape)
+//     }
     
-    return (offsetCopy, scaleCopy)
+//     return (offsetCopy, scaleCopy)
   }
   
 //   @inline(never)

--- a/Sources/TensorFlow/Layers/Normalization.swift
+++ b/Sources/TensorFlow/Layers/Normalization.swift
@@ -124,14 +124,14 @@ public struct BatchNorm<Scalar: TensorFlowFloatingPoint>: Layer {
     
     // Remove this workaround ASAP allow inlining of `doTraining` and `doInference`
     if positiveAxis == input.rank - 1 {
-      callAsFunction1(input)
+      callAsFunction1(input, positiveAxis: positiveAxis)
     } else {
-      callAsFunction2(input)
+      callAsFunction2(input, positiveAxis: positiveAxis)
     }
   }
   
   @inline(never)
-  private func callAsFunction1(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
+  private func callAsFunction1(_ input: Tensor<Scalar>, positiveAxis: Int) -> Tensor<Scalar> {
     let offset = self.offset
       let scale = self.scale
       
@@ -144,7 +144,7 @@ public struct BatchNorm<Scalar: TensorFlowFloatingPoint>: Layer {
   }
   
   @inline(never)
-  private func callAsFunction2(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
+  private func callAsFunction2(_ input: Tensor<Scalar>, positiveAxis: Int) -> Tensor<Scalar> {
     var broadcastShape = TensorShape([Int](repeating: 1, count: input.rank))
       broadcastShape[positiveAxis] = input.shape[positiveAxis]
       let offset = self.offset.reshaped(to: broadcastShape)

--- a/Sources/TensorFlow/Layers/Normalization.swift
+++ b/Sources/TensorFlow/Layers/Normalization.swift
@@ -127,7 +127,7 @@ public struct BatchNorm<Scalar: TensorFlowFloatingPoint>: Layer {
   }
   
   @inline(never)
-  @differentiable(reverse, wrt: (offset, scale))
+  @differentiable(reverse)
   private static func srNameWorkaround(
     offset: Tensor<Scalar>, 
     scale: Tensor<Scalar>,

--- a/Sources/TensorFlow/Layers/Normalization.swift
+++ b/Sources/TensorFlow/Layers/Normalization.swift
@@ -127,7 +127,7 @@ public struct BatchNorm<Scalar: TensorFlowFloatingPoint>: Layer {
   }
   
   @inline(never)
-  @differentiable(wrt: offset, scale)
+  @differentiable(wrt: (offset, scale))
   private static func srNameWorkaround(
     offset: inout Tensor<Scalar>, 
     scale: inout Tensor<Scalar>,

--- a/Sources/TensorFlow/Layers/Normalization.swift
+++ b/Sources/TensorFlow/Layers/Normalization.swift
@@ -115,7 +115,7 @@ public struct BatchNorm<Scalar: TensorFlowFloatingPoint>: Layer {
       } else {
         var broadcastShape = TensorShape([Int](repeating: 1, count: input.rank))
         broadcastShape[positiveAxis] = input.shape[positiveAxis]
-        return (offset.reshaped(to: broadcastShape), scale.reshaped(to: broadcastShape))
+        return (params.offset.reshaped(to: broadcastShape), params.scale.reshaped(to: broadcastShape))
       }
     }
     let (offset, scale) = srNameWorkaround(params: (self.offset, self.scale))

--- a/Sources/TensorFlow/Layers/Normalization.swift
+++ b/Sources/TensorFlow/Layers/Normalization.swift
@@ -129,7 +129,7 @@ public struct BatchNorm<Scalar: TensorFlowFloatingPoint>: Layer {
   
   @inline(never)
   @differentiable(reverse)
-  private static func srNameWorkaround( // if this doesn't work, try a fileprivate generic struct --- remove `public` after debugging
+  internal static func srNameWorkaround( // if this doesn't work, try a fileprivate generic struct --- remove `public` after debugging
     offset: Tensor<Scalar>, 
     scale: Tensor<Scalar>,
     input: Tensor<Scalar>,

--- a/Sources/TensorFlow/Layers/Normalization.swift
+++ b/Sources/TensorFlow/Layers/Normalization.swift
@@ -106,20 +106,6 @@ public struct BatchNorm<Scalar: TensorFlowFloatingPoint>: Layer {
       input.shape[positiveAxis] == offset.shape[0],
       "The number of features of the input and the offset doesn't match.")
     
-//     // Will document the SR name shortly - try @inline(never) if it doesn't work?
-//     func srNameWorkaround(
-//       params: (offset: Tensor<Scalar>, scale: Tensor<Scalar>)
-//     ) -> (offset: Tensor<Scalar>, scale: Tensor<Scalar>) {
-// //       if positiveAxis == input.rank - 1 {
-// //         return params
-// //       } else {
-//         var broadcastShape = TensorShape([Int](repeating: 1, count: input.rank))
-//         broadcastShape[positiveAxis] = input.shape[positiveAxis]
-//         return (params.offset.reshaped(to: broadcastShape), params.scale.reshaped(to: broadcastShape))
-// //       }
-//     }
-//     let (offset, scale) = srNameWorkaround(params: (self.offset, self.scale))
-    
 //     var offset = self.offset
 //     var scale = self.scale
 //     if positiveAxis != input.rank - 1 {
@@ -138,7 +124,15 @@ public struct BatchNorm<Scalar: TensorFlowFloatingPoint>: Layer {
     
     // Remove this workaround ASAP allow inlining of `doTraining` and `doInference`
     if positiveAxis == input.rank - 1 {
-      let offset = self.offset
+      callAsFunction1(input)
+    } else {
+      callAsFunction2(input)
+    }
+  }
+  
+  @inline(never)
+  private func callAsFunction1(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
+    let offset = self.offset
       let scale = self.scale
       
       switch Context.local.learningPhase {
@@ -147,9 +141,11 @@ public struct BatchNorm<Scalar: TensorFlowFloatingPoint>: Layer {
       case .inference:
         return doInference(input, offset: offset, scale: scale)
       }
-    } else {
-      // Might need to extract this into a function
-      var broadcastShape = TensorShape([Int](repeating: 1, count: input.rank))
+  }
+  
+  @inline(never)
+  private func callAsFunction2(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
+    var broadcastShape = TensorShape([Int](repeating: 1, count: input.rank))
       broadcastShape[positiveAxis] = input.shape[positiveAxis]
       let offset = self.offset.reshaped(to: broadcastShape)
       let scale = self.scale.reshaped(to: broadcastShape)
@@ -160,7 +156,6 @@ public struct BatchNorm<Scalar: TensorFlowFloatingPoint>: Layer {
       case .inference:
         return doInference(input, offset: offset, scale: scale)
       }
-    }
   }
 
   private func doTraining(

--- a/Sources/TensorFlow/Layers/Normalization.swift
+++ b/Sources/TensorFlow/Layers/Normalization.swift
@@ -105,7 +105,8 @@ public struct BatchNorm<Scalar: TensorFlowFloatingPoint>: Layer {
     precondition(
       input.shape[positiveAxis] == offset.shape[0],
       "The number of features of the input and the offset doesn't match.")
-    var (offset, scale) = {x in (x.offset, x.scale) }(self)
+    var offset = self.offset
+    var scale = self.scale
     if positiveAxis != input.rank - 1 {
       var broadcastShape = TensorShape([Int](repeating: 1, count: input.rank))
       broadcastShape[positiveAxis] = input.shape[positiveAxis]

--- a/Sources/TensorFlow/Layers/Normalization.swift
+++ b/Sources/TensorFlow/Layers/Normalization.swift
@@ -110,13 +110,13 @@ public struct BatchNorm<Scalar: TensorFlowFloatingPoint>: Layer {
     func srNameWorkaround(
       params: (offset: Tensor<Scalar>, scale: Tensor<Scalar>)
     ) -> (offset: Tensor<Scalar>, scale: Tensor<Scalar>) {
-      if positiveAxis == input.rank - 1 {
-        return params
-      } else {
+//       if positiveAxis == input.rank - 1 {
+//         return params
+//       } else {
         var broadcastShape = TensorShape([Int](repeating: 1, count: input.rank))
         broadcastShape[positiveAxis] = input.shape[positiveAxis]
         return (params.offset.reshaped(to: broadcastShape), params.scale.reshaped(to: broadcastShape))
-      }
+//       }
     }
     let (offset, scale) = srNameWorkaround(params: (self.offset, self.scale))
 //     var offset = self.offset

--- a/Sources/TensorFlow/Layers/Normalization.swift
+++ b/Sources/TensorFlow/Layers/Normalization.swift
@@ -105,26 +105,20 @@ public struct BatchNorm<Scalar: TensorFlowFloatingPoint>: Layer {
     precondition(
       input.shape[positiveAxis] == offset.shape[0],
       "The number of features of the input and the offset doesn't match.")
-//     let offsetOriginal = self.offset
-//     let scaleOriginal = self.scale
-    let offsetOriginal = self.offset
-    let scaleOriginal = self.scale
+//     var offset = self.offset
+//     var scale = self.scale
 //     if positiveAxis != input.rank - 1 {
 //       var broadcastShape = TensorShape([Int](repeating: 1, count: input.rank))
 //       broadcastShape[positiveAxis] = input.shape[positiveAxis]
 //       offset = offset.reshaped(to: broadcastShape)
 //       scale = scale.reshaped(to: broadcastShape)
 //     }
-//     if positiveAxis != input.rank - 1 {
-     let (offset, scale) = Self.srNameWorkaround(offset: offsetOriginal,
-                                                 scale: scaleOriginal,
-                                                 input: input,
-                                                 positiveAxis: positiveAxis)
-//     }
-//     let (offset, scale) = Self.srNameWorkaround(offset: offsetOriginal,
-//                                                 scale: scaleOriginal,
-//                                                 input: input,
-//                                                 positiveAxis: positiveAxis)
+    let offsetOriginal = self.offset
+    let scaleOriginal = self.scale
+    let (offset, scale) = Self.srNameWorkaround(offset: offsetOriginal,
+                                                scale: scaleOriginal,
+                                                input: input,
+                                                positiveAxis: positiveAxis)
     switch Context.local.learningPhase {
     case .training:
       return doTraining(input, offset: offset, scale: scale, axis: positiveAxis)
@@ -141,51 +135,14 @@ public struct BatchNorm<Scalar: TensorFlowFloatingPoint>: Layer {
     input: Tensor<Scalar>,
     positiveAxis: Int
   ) -> (Tensor<Scalar>, Tensor<Scalar>) {
-    var offsetCopy = offset
-    var scaleCopy = offset
-    
     if positiveAxis != input.rank - 1 {
       var broadcastShape = TensorShape([Int](repeating: 1, count: input.rank))
       broadcastShape[positiveAxis] = input.shape[positiveAxis]
-//       return (offset.reshaped(to: broadcastShape), scale.reshaped(to: broadcastShape))
-      offsetCopy = offsetCopy.reshaped(to: broadcastShape)
-      scaleCopy = scaleCopy.reshaped(to: broadcastShape)
+      return (offset.reshaped(to: broadcastShape), scale.reshaped(to: broadcastShape))
     } else {
-//       return (offset, scale)
+      return (offset, scale)
     }
-    
-    return (offsetCopy, scaleCopy)
   }
-  
-//   @inline(never)
-//   @differentiable(reverse, wrt: input)
-//   private func callAsFunction1(_ input: Tensor<Scalar>, positiveAxis: Int) -> Tensor<Scalar> {
-//     let offset = self.offset
-//     let scale = self.scale
-
-//     switch Context.local.learningPhase {
-//     case .training:
-//       return doTraining(input, offset: offset, scale: scale, axis: positiveAxis)
-//     case .inference:
-//       return doInference(input, offset: offset, scale: scale)
-//     }
-//   }
-  
-//   @inline(never)
-//   @differentiable(reverse, wrt: input)
-//   private func callAsFunction2(_ input: Tensor<Scalar>, positiveAxis: Int) -> Tensor<Scalar> {
-//     var broadcastShape = TensorShape([Int](repeating: 1, count: input.rank))
-//     broadcastShape[positiveAxis] = input.shape[positiveAxis]
-//     let offset = self.offset.reshaped(to: broadcastShape)
-//     let scale = self.scale.reshaped(to: broadcastShape)
-
-//     switch Context.local.learningPhase {
-//     case .training:
-//       return doTraining(input, offset: offset, scale: scale, axis: positiveAxis)
-//     case .inference:
-//       return doInference(input, offset: offset, scale: scale)
-//     }
-//   }
 
   private func doTraining(
     _ input: Tensor<Scalar>, offset: Tensor<Scalar>, scale: Tensor<Scalar>, axis: Int

--- a/Sources/TensorFlow/Layers/Normalization.swift
+++ b/Sources/TensorFlow/Layers/Normalization.swift
@@ -141,20 +141,20 @@ public struct BatchNorm<Scalar: TensorFlowFloatingPoint>: Layer {
     input: Tensor<Scalar>,
     positiveAxis: Int
   ) -> (Tensor<Scalar>, Tensor<Scalar>) {
-//     var offsetCopy = offset
-//     var scaleCopy = offset
+    var offsetCopy = offset
+    var scaleCopy = offset
     
     if positiveAxis != input.rank - 1 {
       var broadcastShape = TensorShape([Int](repeating: 1, count: input.rank))
       broadcastShape[positiveAxis] = input.shape[positiveAxis]
-      return (offset.reshaped(to: broadcastShape), scale.reshaped(to: broadcastShape))
-//       offsetCopy = offsetCopy.reshaped(to: broadcastShape)
-//       scaleCopy = scaleCopy.reshaped(to: broadcastShape)
+//       return (offset.reshaped(to: broadcastShape), scale.reshaped(to: broadcastShape))
+      offsetCopy = offsetCopy.reshaped(to: broadcastShape)
+      scaleCopy = scaleCopy.reshaped(to: broadcastShape)
     } else {
-      return (offset, scale)
+//       return (offset, scale)
     }
     
-//     return (offsetCopy, scaleCopy)
+    return (offsetCopy, scaleCopy)
   }
   
 //   @inline(never)

--- a/Sources/TensorFlow/Layers/Normalization.swift
+++ b/Sources/TensorFlow/Layers/Normalization.swift
@@ -133,29 +133,29 @@ public struct BatchNorm<Scalar: TensorFlowFloatingPoint>: Layer {
   @inline(never)
   private func callAsFunction1(_ input: Tensor<Scalar>, positiveAxis: Int) -> Tensor<Scalar> {
     let offset = self.offset
-      let scale = self.scale
-      
-      switch Context.local.learningPhase {
-      case .training:
-        return doTraining(input, offset: offset, scale: scale, axis: positiveAxis)
-      case .inference:
-        return doInference(input, offset: offset, scale: scale)
-      }
+    let scale = self.scale
+
+    switch Context.local.learningPhase {
+    case .training:
+      return doTraining(input, offset: offset, scale: scale, axis: positiveAxis)
+    case .inference:
+      return doInference(input, offset: offset, scale: scale)
+    }
   }
   
   @inline(never)
   private func callAsFunction2(_ input: Tensor<Scalar>, positiveAxis: Int) -> Tensor<Scalar> {
     var broadcastShape = TensorShape([Int](repeating: 1, count: input.rank))
-      broadcastShape[positiveAxis] = input.shape[positiveAxis]
-      let offset = self.offset.reshaped(to: broadcastShape)
-      let scale = self.scale.reshaped(to: broadcastShape)
-      
-      switch Context.local.learningPhase {
-      case .training:
-        return doTraining(input, offset: offset, scale: scale, axis: positiveAxis)
-      case .inference:
-        return doInference(input, offset: offset, scale: scale)
-      }
+    broadcastShape[positiveAxis] = input.shape[positiveAxis]
+    let offset = self.offset.reshaped(to: broadcastShape)
+    let scale = self.scale.reshaped(to: broadcastShape)
+
+    switch Context.local.learningPhase {
+    case .training:
+      return doTraining(input, offset: offset, scale: scale, axis: positiveAxis)
+    case .inference:
+      return doInference(input, offset: offset, scale: scale)
+    }
   }
 
   private func doTraining(

--- a/Sources/TensorFlow/Layers/Normalization.swift
+++ b/Sources/TensorFlow/Layers/Normalization.swift
@@ -116,8 +116,8 @@ public struct BatchNorm<Scalar: TensorFlowFloatingPoint>: Layer {
 //       scale = scale.reshaped(to: broadcastShape)
 //     }
     if positiveAxis != input.rank - 1 {
-      (offset, scale) = Self.srNameWorkaround(offset: offset,
-                                              scale: scale,
+      Self.srNameWorkaround(offset: &offset,
+                                              scale: &scale,
                                               input: input,
                                               positiveAxis: positiveAxis)
     }
@@ -136,18 +136,19 @@ public struct BatchNorm<Scalar: TensorFlowFloatingPoint>: Layer {
   @inline(never)
   @differentiable(reverse)
   private static func srNameWorkaround(
-    offset: Tensor<Scalar>, 
-    scale: Tensor<Scalar>,
+    offset: inout Tensor<Scalar>, 
+    scale: inout Tensor<Scalar>,
     input: Tensor<Scalar>,
     positiveAxis: Int
-  ) -> (Tensor<Scalar>, Tensor<Scalar>) {
+  ) {
 //     var offsetCopy = offset
 //     var scaleCopy = offset
     
 //     if positiveAxis != input.rank - 1 {
       var broadcastShape = TensorShape([Int](repeating: 1, count: input.rank))
       broadcastShape[positiveAxis] = input.shape[positiveAxis]
-      return (offset.reshaped(to: broadcastShape), scale.reshaped(to: broadcastShape))
+      offset = offset.reshaped(to: broadcastShape)
+      shape = scale.reshaped(to: broadcastShape)
 //       offsetCopy = offsetCopy.reshaped(to: broadcastShape)
 //       scaleCopy = scaleCopy.reshaped(to: broadcastShape)
 //     }

--- a/Sources/TensorFlow/Layers/Normalization.swift
+++ b/Sources/TensorFlow/Layers/Normalization.swift
@@ -131,6 +131,7 @@ public struct BatchNorm<Scalar: TensorFlowFloatingPoint>: Layer {
   }
   
   @inline(never)
+  @differentiable(reverse, wrt: input)
   private func callAsFunction1(_ input: Tensor<Scalar>, positiveAxis: Int) -> Tensor<Scalar> {
     let offset = self.offset
     let scale = self.scale
@@ -144,6 +145,7 @@ public struct BatchNorm<Scalar: TensorFlowFloatingPoint>: Layer {
   }
   
   @inline(never)
+  @differentiable(reverse, wrt: input)
   private func callAsFunction2(_ input: Tensor<Scalar>, positiveAxis: Int) -> Tensor<Scalar> {
     var broadcastShape = TensorShape([Int](repeating: 1, count: input.rank))
     broadcastShape[positiveAxis] = input.shape[positiveAxis]

--- a/Sources/TensorFlow/Layers/Normalization.swift
+++ b/Sources/TensorFlow/Layers/Normalization.swift
@@ -113,7 +113,6 @@ public struct BatchNorm<Scalar: TensorFlowFloatingPoint>: Layer {
       var broadcastShape = TensorShape([Int](repeating: 1, count: input.rank))
       broadcastShape[positiveAxis] = input.shape[positiveAxis]
       offset = offset.reshaped(to: broadcastShape)
-
       scale = scale.reshaped(to: broadcastShape)
     }
 //     let (offset, scale) = Self.srNameWorkaround(offset: offsetOriginal,


### PR DESCRIPTION
Summary: half-fix for `BatchNorm` compiler crash

On debug and release (only with -Onone), this compiles successfully. On fully optimized release, this still fails to compile and produces the stack trace mentioned in https://github.com/apple/swift/pull/38745#issuecomment-947890567. In short, I independently implemented your "number of patches".

This was tested on Google Colab (dual-core x64) with the 2021-11-12 toolchain. Later toolchains introduce other bugs that prevent compilation in RecurrentLayer  - https://github.com/tensorflow/swift-apis/pull/1184#issuecomment-1008006067.

Let's try keeping as much discussion as possible on https://github.com/tensorflow/swift-apis/issues/1189#issue-1097286651. A PR on a fork isn't as accessible as something created on tensorflow's repo.